### PR TITLE
Update InSpec 7 licensing documentation

### DIFF
--- a/content/install/license.md
+++ b/content/install/license.md
@@ -15,7 +15,7 @@ To use Chef InSpec 7, you must [accept the Chef EULA](#accept-the-chef-eula).
 
 Chef InSpec 7 introduces an updated licensing model designed to simplify usage while maintaining compliance across distribution channels.
 
-For software downloaded from official Progress distribution channels, license enforcement does not occur at runtime. Instead, license verification may occur during the download process.
+For software downloaded from official Progress distribution channels, a license key is not required when running InSpec.
 
 Official distribution channels include:
 
@@ -27,19 +27,6 @@ When InSpec is obtained from these official sources, a license key is not requir
 ### Software obtained from non-official sources
 
 If InSpec is installed from sources outside the official Progress distribution channels—such as public Ruby gems or other external repositories—a valid license may be required to execute the software.
-
-### Workflows that download binaries
-
-Some workflows may download Chef binaries as part of their execution. Examples include:
-
-- `knife bootstrap`
-- `kitchen converge`
-
-If these workflows download binaries from Chef APIs or official Progress distribution services, a license key may be required to complete the download.
-
-If the binaries are downloaded from an internal or user-managed source, license enforcement does not apply.
-
-You can't manually enable or disable licensing. The licensing requirements are determined by the distribution.
 
 If you'd like to try out Chef InSpec, you can [request a trial license](https://www.chef.io/licensing/inspec/license-generation-free-trial).
 

--- a/content/install/license.md
+++ b/content/install/license.md
@@ -10,27 +10,7 @@ draft = false
 +++
 
 To use Chef InSpec 7, you must [accept the Chef EULA](#accept-the-chef-eula).
-
-## Licensing behavior
-
-Chef InSpec 7 introduces an updated licensing model designed to simplify usage while maintaining compliance across distribution channels.
-
-For software downloaded from official Progress distribution channels, a license key isn't required when running InSpec.
-
-Official distribution channels include:
-
-- The Progress Download Portal
-- Habitat-based package distribution
-
-When InSpec is obtained from these official sources, a license key isn't required to execute the software after installation.
-
-### Software obtained from non-official sources
-
-If InSpec is installed from sources outside the official Progress distribution channels---such as public Ruby gems or other external repositories---a valid license may be required to execute the software.
-
-If you'd like to try out Chef InSpec, you can [request a trial license](https://www.chef.io/licensing/inspec/license-generation-free-trial).
-
-For more information, see [Chef's licensing documentation](https://docs.chef.io/licensing/).
+Depending on how you obtained Chef InSpec, you may also need to [add a Progress Chef license key](#progress-chef-license).
 
 ## Accept the Chef EULA
 
@@ -39,7 +19,7 @@ You must accept the [Chef End User License Agreement (EULA)](https://www.chef.io
 - [Use a command line option](#use-a-command-line-option)
 - [Set an environment variable](#set-an-environment-variable)
 
-If you don't set either, Chef InSpec prompts you to accept the EULA interactively. If the prompt can't be displayed, Chef InSpec exits with code 172.
+If you don't use either method, Chef InSpec prompts you to accept the EULA interactively. If the prompt can't be displayed, Chef InSpec exits with code 172.
 
 If Chef InSpec can't persist the accepted license, it sends a message to STDOUT and continues to run. You'll need to accept the license again the next time you run Chef InSpec.
 
@@ -82,14 +62,29 @@ Replace `<value>` with one of these options:
 `accept-no-persist`
 : Similar to `accept-silent`, but doesn't persist a marker file. You'll need to accept the license again for future runs.
 
-## Add a license
+## Progress Chef license
 
-The `inspec` gem requires a license to execute.
-You can add a license key in three ways:
+### License key requirements
+
+Chef InSpec 7 introduces an updated licensing model designed to simplify usage while maintaining compliance across distribution channels.
+
+If you download InSpec from the following official Progress distribution channels, a license key isn't required to execute InSpec after it's installed:
+
+- The Progress Download Portal
+- Habitat-based package distribution
+- The Chef Commercial Downloads API
+
+If you download Chef InSpec from sources outside the official Progress distribution channels---such as public Ruby gems or other external repositories---a valid license may be required to execute the software.
+
+For more information, see [Chef's licensing documentation](https://docs.chef.io/licensing/).
+
+### Add a license key
+
+If you downloaded Chef InSpec from sources outside the official Progress distribution channels, use one of the following methods to add a license key:
 
 - [Use the interactive license dialog](#use-the-interactive-license-dialog)
-- [command line option](#use-a-command-line-option-1)
-- [environment variable](#set-an-environment-variable-1)
+- [Use a command line option](#use-a-command-line-option-1)
+- [Set an environment variable](#set-an-environment-variable-1)
 
 {{< note >}}
 
@@ -97,7 +92,7 @@ If you're a commercial customer, you can use an asset serial number from the [Pr
 
 {{< /note >}}
 
-### Use the interactive license dialog
+#### Use the interactive license dialog
 
 The easiest way to provide a license key is to run Chef InSpec.
 If no license key is set and it doesn't detect an automated method of setting a license key, Chef InSpec starts an interactive licensing dialog.
@@ -111,7 +106,7 @@ To add a license with the interactive license dialog, follow these steps:
 
 Chef InSpec validates your license key, displays license details, runs `inspec shell`, and stores the key for future use.
 
-### Use a command line option
+#### Use a command line option
 
 Set the license key with the `--chef-license-key` option:
 
@@ -119,9 +114,9 @@ Set the license key with the `--chef-license-key` option:
 inspec exec <PROFILE_NAME> --chef-license-key <LICENSE_KEY>
 ```
 
-Most of the main Chef InSpec CLI commands accept this argument, however some plugins don't support the flag.
+Most Chef InSpec CLI commands accept this argument, but some plugins don't support the flag.
 
-### Set an environment variable
+#### Set an environment variable
 
 Set the license key with the `CHEF_LICENSE_KEY` environment variable:
 
@@ -130,9 +125,9 @@ export CHEF_LICENSE_KEY=<LICENSE_KEY>
 inspec exec <PROFILE_NAME>
 ```
 
-## Add a license with Chef's Local License Service
+### Add a license with Chef's Local License Service
 
-For large or air-gapped fleets, you can retrieve a license key from a [Chef Local License Service](https://docs.chef.io/licensing/local_license_service/). With this service, you only need the service URLs.
+For large or air-gapped fleets, you can retrieve a license key from a [Chef Local License Service](https://docs.chef.io/licensing/local_license_service/). With this service, you only need the Local License Service URL.
 Chef InSpec requests license keys from the Local License Service and uses them during execution. Chef InSpec doesn't store these keys long-term.
 
 You can set a Local License Service URL in two ways:
@@ -140,7 +135,7 @@ You can set a Local License Service URL in two ways:
 - [Use a command line option](#use-a-command-line-option-2)
 - [Set an environment variable](#set-an-environment-variable-2)
 
-### Use a command line option
+#### Use a command line option
 
 Set the Chef Local License Service URL with the `--chef-license-server` option:
 
@@ -148,7 +143,7 @@ Set the Chef Local License Service URL with the `--chef-license-server` option:
 inspec exec <PROFILE_NAME> --chef-license-server https://license-server.example.com
 ```
 
-### Set an environment variable
+#### Set an environment variable
 
 Set the Chef Local License Service URL with the `CHEF_LICENSE_SERVER` environment variable:
 
@@ -157,7 +152,7 @@ export CHEF_LICENSE_SERVER=https://license-server.example.com
 inspec exec <PROFILE_NAME>
 ```
 
-#### Use multiple license servers
+##### Use multiple license servers
 
 You can set up to five Chef Local License Service URLs as a comma-separated list. Chef InSpec tries each URL and uses the first one that works.
 
@@ -166,9 +161,13 @@ export CHEF_LICENSE_SERVER=https://license-server-01.example.com,https://license
 inspec exec <PROFILE_NAME>
 ```
 
-Make sure you synchronize your license servers to avoid inconsistent results.
+Synchronize your license servers to avoid inconsistent results.
 
-## Licensing Telemetry service
+## Trial license
+
+If you'd like to try out Chef InSpec, you can [request a trial Progress Chef license](https://www.chef.io/licensing/inspec/license-generation-free-trial).
+
+## Licensing telemetry service
 
 The Chef Licensing Telemetry service gathers product activation, usage statistics, environment information, bugs, and other data related to Chef InSpec.
 

--- a/content/install/license.md
+++ b/content/install/license.md
@@ -9,11 +9,35 @@ draft = false
     weight = 30
 +++
 
-To use Chef InSpec 7, you need to [accept the Chef EULA](#accept-the-chef-eula).
-Depending on the InSpec distribution you install, you need a [license](#add-a-license) to execute InSpec:
+To use Chef InSpec 7, you must [accept the Chef EULA](#accept-the-chef-eula).
 
-- The Chef Habitat package for InSpec 7 doesn't require a license to execute InSpec.
-- The `inspec` gem requires a license to execute InSpec.
+## Licensing behavior
+
+Chef InSpec 7 introduces an updated licensing model designed to simplify usage while maintaining compliance across distribution channels.
+
+For software downloaded from official Progress distribution channels, license enforcement does not occur at runtime. Instead, license verification may occur during the download process.
+
+Official distribution channels include:
+
+- The Progress Download Portal
+- Habitat-based package distribution
+
+When InSpec is obtained from these official sources, a license key is not required to execute the software after installation.
+
+### Software obtained from non-official sources
+
+If InSpec is installed from sources outside the official Progress distribution channels—such as public Ruby gems or other external repositories—a valid license may be required to execute the software.
+
+### Workflows that download binaries
+
+Some workflows may download Chef binaries as part of their execution. Examples include:
+
+- `knife bootstrap`
+- `kitchen converge`
+
+If these workflows download binaries from Chef APIs or official Progress distribution services, a license key may be required to complete the download.
+
+If the binaries are downloaded from an internal or user-managed source, license enforcement does not apply.
 
 You can't manually enable or disable licensing. The licensing requirements are determined by the distribution.
 

--- a/content/install/license.md
+++ b/content/install/license.md
@@ -15,18 +15,18 @@ To use Chef InSpec 7, you must [accept the Chef EULA](#accept-the-chef-eula).
 
 Chef InSpec 7 introduces an updated licensing model designed to simplify usage while maintaining compliance across distribution channels.
 
-For software downloaded from official Progress distribution channels, a license key is not required when running InSpec.
+For software downloaded from official Progress distribution channels, a license key isn't required when running InSpec.
 
 Official distribution channels include:
 
 - The Progress Download Portal
 - Habitat-based package distribution
 
-When InSpec is obtained from these official sources, a license key is not required to execute the software after installation.
+When InSpec is obtained from these official sources, a license key isn't required to execute the software after installation.
 
 ### Software obtained from non-official sources
 
-If InSpec is installed from sources outside the official Progress distribution channels—such as public Ruby gems or other external repositories—a valid license may be required to execute the software.
+If InSpec is installed from sources outside the official Progress distribution channels---such as public Ruby gems or other external repositories---a valid license may be required to execute the software.
 
 If you'd like to try out Chef InSpec, you can [request a trial license](https://www.chef.io/licensing/inspec/license-generation-free-trial).
 


### PR DESCRIPTION
Updates the InSpec 7 licensing documentation to reflect the updated licensing model introduced for Progress Chef products.

## Description
This change updates the licensing explanation in the InSpec documentation to reflect the current licensing behavior. The previous text described licensing based only on distribution type (Habitat package vs Ruby gem).  

The updated section clarifies that:
- License enforcement for official Progress distribution channels occurs during the download process rather than at runtime.
- InSpec obtained from unofficial sources (for example public Ruby gems) may require a license to execute.
- Certain workflows that download binaries (such as `knife bootstrap` and `kitchen converge`) may require a license if the binaries are retrieved from Chef APIs.

## Chef InSpec versions
InSpec 7

## Issues resolved
N/A

## Related PRs
N/A

## Checklist
- [x] spellcheck
- [x] all tests pass