### PR TITLE
Doc changes for trust_server_certificate option in mssql_session resource

### DIFF
--- a/content/resources/core/mssql_session.md
+++ b/content/resources/core/mssql_session.md
@@ -34,57 +34,48 @@ end
 
 where:
 
-- `mssql_session` declares credentials and connection settings with permission to run the query.
+- `mssql_session` declares credentials and connection settings used to connect to Microsoft SQL Server
 - `query('QUERY')` contains the query to be run
 - `its('value') { should eq('') }` compares the results of the query against the expected result in the test
 
 ### Optional parameters
 
-The `mssql_session` resource accepts `user`, `password`, `pass`, `host`, `port`, `instance`, `db_name`, `local_mode`, and `trust_server_certificate`.
+This resource has the following parameters:
 
-#### `user`
+`user`
+: The SQL Server username for SQL authentication.
 
-The SQL Server username for SQL authentication.
+  If `user` or `password` is omitted, `mssql_session` uses Windows authentication as the user running Chef InSpec.
 
-If `user` or `password` is omitted, `mssql_session` uses Windows authentication as the user running Chef InSpec.
+`password`
+: The SQL Server password for SQL authentication.
 
-#### `password`
+`pass` (deprecated)
+: Deprecated alias for `password`. Use `password` instead.
 
-The SQL Server password for SQL authentication.
+`host`
+: The SQL Server host name. Default value: `localhost`.
 
-#### `pass` (deprecated)
+`port`
+: The SQL Server port. By default, no explicit port is passed.
 
-Deprecated alias for `password`. Use `password` instead.
+`instance`
+: The SQL Server instance name. By default, the server's default instance is used.
 
-#### `host`
+`db_name`
+: The database name to connect to before running the query.
 
-The SQL Server host name. Default value: `localhost`.
+`local_mode`
+: Set to `true` to run in local mode.
 
-#### `port`
+  In local mode, the resource doesn't pass the host or port to `sqlcmd`.
 
-The SQL Server port. By default, no explicit port is passed.
+`trust_server_certificate`
+: Set `trust_server_certificate: true` to pass `-C` to the underlying `sqlcmd`.
 
-#### `instance`
+  Use this when you need encrypted connectivity, but certificate validation would otherwise fail due to missing certificate-chain configuration (for example, SQL Server uses a self-signed certificate or a private CA that isn't available in the runner's trust store).
 
-The SQL Server instance name. By default, the server's default instance is used.
-
-#### `db_name`
-
-The database name to connect to before running the query.
-
-#### `local_mode`
-
-Set to `true` to run in local mode.
-
-In local mode, the resource doesn't pass the host or port to `sqlcmd`.
-
-#### `trust_server_certificate`
-
-Set `trust_server_certificate: true` to pass `-C` to the underlying `sqlcmd`.
-
-Use this when you need encrypted connectivity, but certificate validation would otherwise fail due to missing certificate-chain configuration (for example, SQL Server uses a self-signed certificate or a private CA that isn't available in the runner trust store).
-
-This option is less secure than full certificate validation because it trusts the server certificate without strict verification. Only use it when necessary. Instead, you should install the correct CA/server certificates on the target system when possible.
+  This option is less secure than full certificate validation because it trusts the server certificate without strict verification. Use this only if necessary. Instead, install the correct CA certificate or SQL Server certificate on the target system when possible.
 
 ## Examples
 

--- a/content/resources/core/mssql_session.md
+++ b/content/resources/core/mssql_session.md
@@ -38,13 +38,13 @@ where:
 - `query('QUERY')` contains the query to be run
 - `its('value') { should eq('') }` compares the results of the query against the expected result in the test
 
-### Optional Parameters
+### Optional parameters
 
 The `mssql_session` resource accepts `user`, `password`, `pass`, `host`, `port`, `instance`, `db_name`, `local_mode`, and `trust_server_certificate`.
 
 #### `user`
 
-The SQL Server user name for SQL authentication.
+The SQL Server username for SQL authentication.
 
 If `user` or `password` is omitted, `mssql_session` uses Windows authentication as the user running Chef InSpec.
 
@@ -76,7 +76,7 @@ The database name to connect to before running the query.
 
 Set to `true` to run in local mode.
 
-In local mode, the resource doesn't pass host or port to `sqlcmd`.
+In local mode, the resource doesn't pass the host or port to `sqlcmd`.
 
 #### `trust_server_certificate`
 
@@ -84,7 +84,7 @@ Set `trust_server_certificate: true` to pass `-C` to the underlying `sqlcmd`.
 
 Use this when you need encrypted connectivity, but certificate validation would otherwise fail due to missing certificate-chain configuration (for example, SQL Server uses a self-signed certificate or a private CA that isn't available in the runner trust store).
 
-This option is less secure than full certificate validation because it trusts the server certificate without strict verification. Use it only when necessary, and prefer installing the correct CA/server certificates on the target system when possible.
+This option is less secure than full certificate validation because it trusts the server certificate without strict verification. Only use it when necessary. Instead, you should install the correct CA/server certificates on the target system when possible.
 
 ## Examples
 

--- a/content/resources/core/mssql_session.md
+++ b/content/resources/core/mssql_session.md
@@ -34,9 +34,57 @@ end
 
 where:
 
-- `mssql_session` declares a username and password with permission to run the query. Omitting the username or password parameters results in the use of Windows authentication as the user Chef InSpec is executing as. You may also optionally pass a host and instance name. If omitted, they will default to host: localhost and the default instance.
+- `mssql_session` declares credentials and connection settings with permission to run the query.
 - `query('QUERY')` contains the query to be run
 - `its('value') { should eq('') }` compares the results of the query against the expected result in the test
+
+### Optional Parameters
+
+The `mssql_session` resource accepts `user`, `password`, `pass`, `host`, `port`, `instance`, `db_name`, `local_mode`, and `trust_server_certificate`.
+
+#### `user`
+
+The SQL Server user name for SQL authentication.
+
+If `user` or `password` is omitted, `mssql_session` uses Windows authentication as the user running Chef InSpec.
+
+#### `password`
+
+The SQL Server password for SQL authentication.
+
+#### `pass` (deprecated)
+
+Deprecated alias for `password`. Use `password` instead.
+
+#### `host`
+
+The SQL Server host name. Default value: `localhost`.
+
+#### `port`
+
+The SQL Server port. By default, no explicit port is passed.
+
+#### `instance`
+
+The SQL Server instance name. By default, the server's default instance is used.
+
+#### `db_name`
+
+The database name to connect to before running the query.
+
+#### `local_mode`
+
+Set to `true` to run in local mode.
+
+In local mode, the resource does not pass host or port to `sqlcmd`.
+
+#### `trust_server_certificate`
+
+Set `trust_server_certificate: true` to pass `-C` to the underlying `sqlcmd`.
+
+Use this when you need encrypted connectivity, but certificate validation would otherwise fail due to missing certificate-chain configuration (for example, SQL Server uses a self-signed certificate or a private CA that isn't available in the runner trust store).
+
+This option is less secure than full certificate validation because it trusts the server certificate without strict verification. Use it only when necessary, and prefer installing the correct CA/server certificates on the target system when possible.
 
 ## Examples
 
@@ -79,6 +127,16 @@ sql = mssql_session(user: 'my_user', password: 'password', db_name: 'test')
 
 describe sql.query("SELECT Name AS result FROM Product WHERE ProductID == 1").row(0).column('result') do
   its("value") { should eq 'foo' }
+end
+```
+
+### Trust the SQL Server certificate
+
+```ruby
+sql = mssql_session(user: 'my_user', password: 'password', trust_server_certificate: true)
+
+describe sql.query("SELECT SERVERPROPERTY('ProductVersion') as result").row(0).column('result') do
+  its("value") { should_not be_empty }
 end
 ```
 

--- a/content/resources/core/mssql_session.md
+++ b/content/resources/core/mssql_session.md
@@ -76,7 +76,7 @@ The database name to connect to before running the query.
 
 Set to `true` to run in local mode.
 
-In local mode, the resource does not pass host or port to `sqlcmd`.
+In local mode, the resource doesn't pass host or port to `sqlcmd`.
 
 #### `trust_server_certificate`
 

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -39,6 +39,7 @@ ignoreRegExpList:
 words:
   - TCPS
   - tnsnames
+  - sqlcmd
 languageSettings:
   - languageId: markdown
     ignoreRegExpList:


### PR DESCRIPTION
## Description

<!-- Describe what this change achieves -->
- Doc changes for `trust_server_certificate` option in `mssql_session` resource
- These changes will be released with the latest InSpec 7 release for version `7.1.*`

## Chef InSpec versions

<!-- The InSpec versions that this updates. -->

## Issues resolved

<!-- List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant -->

## Related PRs

## Checklist

- [ ] spellcheck
- [ ] all tests pass
