### PR TITLE
Document macOS Apple Silicon support in install guide

### DIFF
--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -11,8 +11,8 @@ draft = false
 
 <!-- cSpell:ignore -->
 
-Chef InSpec 7 installers are available for Windows, Debian, and RPM-based Linux distributions.
-You can download and install pre-built `.msi`, `.deb`, or `.rpm` packages using your existing package management tools.
+Chef InSpec 7 installers are available for Windows, Debian, RPM-based Linux distributions, and macOS.
+You can download and install pre-built `.msi`, `.deb`, `.rpm`, or `.dmg` packages using your existing package management tools.
 
 ## Supported platforms
 
@@ -20,6 +20,7 @@ Chef InSpec is supported on the following platforms:
 
 - Windows x86-64
 - Linux x86-64
+- macOS Apple Silicon (ARM-64)
 
 ## Prerequisites
 
@@ -32,6 +33,7 @@ This installation process has the following prerequisites:
 - On Windows systems, `tar` is installed.
 - On Debian-based systems, the `dpkg` package manager is installed.
 - On RPM-based systems, `rpm` and either `dnf` or `yum` are installed. For Amazon Linux 2, use `rpm` and `yum`.
+- On macOS systems, you have administrator access to run the `installer` command.
 - You have a valid Progress Chef license key.
 - The target system is connected to the internet.
 
@@ -154,6 +156,53 @@ To install Chef InSpec on Windows, follow these steps:
       Replace `<VERSION>` with the version number of the downloaded package, for example `inspec-enterprise-7.1.6-1_x64.msi`.
 
     - Double-click the `.msi` file and follow the on-screen installation wizard.
+
+1. Verify that Chef InSpec is installed:
+
+    ```sh
+    inspec version
+    ```
+
+    The output displays the installed Chef InSpec version.
+
+1. [Accept the Chef EULA](license#accept-the-chef-eula).
+
+### Install Chef InSpec on macOS
+
+Chef InSpec supports macOS on Apple Silicon (ARM-64) devices.
+
+To install Chef InSpec on macOS, follow these steps:
+
+1. Download the macOS installer using one of the following methods:
+
+    - Download using `wget`:
+
+      ```sh
+      wget -O "inspec-enterprise-<VERSION>-macos.dmg" "https://chefdownload-commercial.chef.io/stable/inspec/download?eol=false&license_id=<LICENSE_ID>&m=aarch64&p=mac_os_x&pm=dmg&v=<VERSION>"
+      ```
+
+    - Download using `curl`:
+
+      ```sh
+      curl -o "inspec-enterprise-<VERSION>-macos.dmg" "https://chefdownload-commercial.chef.io/stable/inspec/download?eol=false&license_id=<LICENSE_ID>&m=aarch64&p=mac_os_x&pm=dmg&v=<VERSION>"
+      ```
+
+    Replace:
+
+    - `<VERSION>` with the version number to install.
+    - `<LICENSE_ID>` with your Chef license ID.
+
+1. Install Chef InSpec:
+
+    ```sh
+    hdiutil attach inspec-enterprise-<VERSION>-macos.dmg
+    sudo installer -pkg "/Volumes/inspec-enterprise-<VERSION>/inspec-enterprise-<VERSION>.pkg" -target /
+    hdiutil detach "/Volumes/inspec-enterprise-<VERSION>"
+    ```
+
+    Replace `<VERSION>` with the version number of the downloaded package, for example `inspec-enterprise-7.1.6-1.arm64.dmg`.
+
+    You can also double-click the downloaded `.dmg` file and follow the on-screen installation wizard.
 
 1. Verify that Chef InSpec is installed:
 

--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -204,7 +204,7 @@ To install Chef InSpec on macOS, follow these steps:
     sudo installer -pkg "/Volumes/<MOUNTED_VOLUME_NAME>/inspec-enterprise-<VERSION>.pkg" -target /
     ```
 
-    Replace `<MOUNTED_VOLUME_NAME>` with the name of the mounted `.dmg` volume, and `<VERSION>` with the version number of the downloaded package.
+    Replace `<MOUNTED_VOLUME_NAME>` with the name of the mounted `.dmg` volume, and `<VERSION>` with the version number of the downloaded package, for example `inspec-enterprise-7.1.16-1.arm64.pkg`.
 
 1. Unmount the disk image:
 

--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -196,13 +196,21 @@ To install Chef InSpec on macOS, follow these steps:
 
     ```sh
     hdiutil attach inspec-enterprise-<VERSION>-macos.dmg
-    sudo installer -pkg "/Volumes/inspec-enterprise-<VERSION>/inspec-enterprise-<VERSION>.pkg" -target /
-    hdiutil detach "/Volumes/inspec-enterprise-<VERSION>"
     ```
 
-    Replace `<VERSION>` with the version number of the downloaded package, for example `inspec-enterprise-7.1.6-1.arm64.dmg`.
+    Then, from the mounted volume shown in Finder, double-click the `.pkg` file and follow the on-screen installation wizard, or install it from the command line:
 
-    You can also double-click the downloaded `.dmg` file and follow the on-screen installation wizard.
+    ```sh
+    sudo installer -pkg "/Volumes/<MOUNTED_VOLUME_NAME>/inspec-enterprise-<VERSION>.pkg" -target /
+    ```
+
+    Replace `<MOUNTED_VOLUME_NAME>` with the name of the mounted `.dmg` volume, and `<VERSION>` with the version number of the downloaded package.
+
+1. Unmount the disk image:
+
+    ```sh
+    hdiutil detach "/Volumes/<MOUNTED_VOLUME_NAME>"
+    ```
 
 1. Verify that Chef InSpec is installed:
 

--- a/content/uninstall.md
+++ b/content/uninstall.md
@@ -63,22 +63,36 @@ To uninstall Chef InSpec, follow these steps:
 
 To uninstall Chef InSpec on macOS, follow these steps:
 
-1. Remove the installed files:
+1. Remove the `inspec` symlink:
 
    ```sh
-   sudo rm -rf /opt/inspec
+   sudo rm -f /usr/local/bin/inspec
    ```
+
+1. Remove the installed application files:
+
+   ```sh
+   sudo rm -rf "/Library/Application Support/InSpec"
+   ```
+
+1. Remove the underlying Habitat package files:
+
+   ```sh
+   sudo rm -rf /opt/hab
+   ```
+
+   Skip this step if you use Habitat for other packages on this system.
 
 1. Remove the package receipt:
 
    ```sh
-   sudo pkgutil --forget com.getchef.pkg.inspec
+   sudo pkgutil --forget io.chef.inspec-enterprise
    ```
 
 1. Verify that the package has been removed:
 
    ```sh
-   pkgutil --pkgs | grep com.getchef.pkg.inspec
+   pkgutil --pkgs | grep io.chef.inspec-enterprise
    ```
 
    The command returns no output if the package is removed successfully.

--- a/content/uninstall.md
+++ b/content/uninstall.md
@@ -59,6 +59,30 @@ To uninstall Chef InSpec, follow these steps:
 
    The command returns no output if the package is removed successfully.
 
+## Uninstall Chef InSpec on macOS
+
+To uninstall Chef InSpec on macOS, follow these steps:
+
+1. Remove the installed files:
+
+   ```sh
+   sudo rm -rf /opt/inspec
+   ```
+
+1. Remove the package receipt:
+
+   ```sh
+   sudo pkgutil --forget com.getchef.pkg.inspec
+   ```
+
+1. Verify that the package has been removed:
+
+   ```sh
+   pkgutil --pkgs | grep com.getchef.pkg.inspec
+   ```
+
+   The command returns no output if the package is removed successfully.
+
 ## Uninstall Chef InSpec on Windows
 
 To uninstall using the Windows UI:


### PR DESCRIPTION
## Summary
Documents support for macOS on Apple Silicon (ARM-64) in the Chef InSpec install guide.

- Added macOS Apple Silicon (ARM-64) to the supported platforms list.
- Added a new **Install Chef InSpec on macOS** section with `.dmg` download and install instructions using `hdiutil`/`installer`.

## Related story
https://progresssoftware.atlassian.net/browse/CHEF-34582 # Parent story
https://progresssoftware.atlassian.net/browse/CHEF-34793